### PR TITLE
Update index.rst

### DIFF
--- a/doc/en/user/source/security/tutorials/digest/index.rst
+++ b/doc/en/user/source/security/tutorials/digest/index.rst
@@ -92,7 +92,7 @@ Test a digest authentication login
 
 #. Ensure that basic authentication is disabled execute the following curl command::
 
-     curl -v -u admin:geoserver -G "http://localhost:8080/geoserve/wfs?request=getcapabilities"
+     curl -v -u admin:geoserver -G "http://localhost:8080/geoserver/wfs?request=getcapabilities"
    
    The result should be a 401 response signaling that authentication is required. The output 
    should look something like the following::


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
There is a basic typo mistake at https://docs.geoserver.org/main/en/user/security/tutorials/digest/index.html#test-a-digest-authentication-login where `geoserver` is written as `geoserve`

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
